### PR TITLE
Fixes for master to work with traffic-engine 0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
       <version>12.2</version>
     </dependency>
     <dependency>
-  		<groupId>com.conveyal</groupId>
+  		<groupId>io.opentraffic</groupId>
   		<artifactId>traffic-engine</artifactId>
   		<version>0.3</version>
     </dependency>

--- a/src/main/java/com/conveyal/traffic/app/TrafficEngineApp.java
+++ b/src/main/java/com/conveyal/traffic/app/TrafficEngineApp.java
@@ -1,6 +1,29 @@
 package com.conveyal.traffic.app;
 
-import java.awt.Rectangle;
+import com.conveyal.traffic.app.data.StatsObject;
+import com.conveyal.traffic.app.data.TrafficPath;
+import com.conveyal.traffic.app.data.WeekObject;
+import com.conveyal.traffic.app.data.WeeklyStatsObject;
+import com.conveyal.traffic.app.engine.Engine;
+import com.conveyal.traffic.app.routing.Routing;
+import com.conveyal.traffic.app.tiles.TrafficTileRequest.DataTile;
+import com.conveyal.traffic.app.tiles.TrafficTileRequest.SegmentTile;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vividsolutions.jts.geom.Envelope;
+import io.opentraffic.engine.data.SpatialDataItem;
+import io.opentraffic.engine.data.pbf.ExchangeFormat;
+import io.opentraffic.engine.data.stats.SegmentStatistics;
+import io.opentraffic.engine.data.stats.SummaryStatistics;
+import io.opentraffic.engine.data.stats.SummaryStatisticsComparison;
+import io.opentraffic.engine.geom.GPSPoint;
+import io.opentraffic.engine.geom.StreetSegment;
+import org.mapdb.Fun;
+import org.opentripplanner.common.model.GenericLocation;
+import org.opentripplanner.routing.core.RoutingRequest;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.core.TraverseModeSet;
+
+import java.awt.*;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -9,37 +32,20 @@ import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.temporal.ChronoField;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import com.conveyal.traffic.app.data.TrafficPath;
-import com.conveyal.traffic.app.data.WeekObject;
-import com.conveyal.traffic.app.data.WeeklyStatsObject;
-import com.conveyal.traffic.app.engine.Engine;
-import com.conveyal.traffic.data.SpatialDataItem;
-import com.conveyal.traffic.data.stats.SummaryStatistics;
-import com.conveyal.traffic.data.stats.SummaryStatisticsComparison;
-import com.conveyal.traffic.geom.StreetSegment;
-import com.conveyal.traffic.data.stats.SegmentStatistics;
-import com.vividsolutions.jts.geom.Envelope;
-import org.mapdb.Fun;
-import org.opentripplanner.common.model.GenericLocation;
-import org.opentripplanner.routing.core.RoutingRequest;
-import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.core.TraverseModeSet;
-
-import com.conveyal.traffic.data.pbf.ExchangeFormat;
-import com.conveyal.traffic.geom.GPSPoint;
-import com.conveyal.traffic.app.data.StatsObject;
-import com.conveyal.traffic.app.routing.Routing;
-import com.conveyal.traffic.app.tiles.TrafficTileRequest.DataTile;
-import com.conveyal.traffic.app.tiles.TrafficTileRequest.SegmentTile;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static spark.Spark.*;
+import static spark.Spark.get;
+import static spark.Spark.post;
+import static spark.Spark.staticFileLocation;
 
 public class TrafficEngineApp {
 	

--- a/src/main/java/com/conveyal/traffic/app/data/TrafficPath.java
+++ b/src/main/java/com/conveyal/traffic/app/data/TrafficPath.java
@@ -1,7 +1,7 @@
 package com.conveyal.traffic.app.data;
 
-import com.conveyal.traffic.data.stats.SummaryStatistics;
-import com.conveyal.traffic.geom.StreetSegment;
+import io.opentraffic.engine.data.stats.SummaryStatistics;
+import io.opentraffic.engine.geom.StreetSegment;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/conveyal/traffic/app/data/TrafficPathEdge.java
+++ b/src/main/java/com/conveyal/traffic/app/data/TrafficPathEdge.java
@@ -1,7 +1,7 @@
 package com.conveyal.traffic.app.data;
 
-import com.conveyal.traffic.data.stats.SummaryStatistics;
-import com.conveyal.traffic.geom.StreetSegment;
+import io.opentraffic.engine.data.stats.SummaryStatistics;
+import io.opentraffic.engine.geom.StreetSegment;
 import org.jcolorbrewer.ColorBrewer;
 import org.opentripplanner.util.PolylineEncoder;
 import org.opentripplanner.util.model.EncodedPolylineBean;

--- a/src/main/java/com/conveyal/traffic/app/data/WeeklyStatsObject.java
+++ b/src/main/java/com/conveyal/traffic/app/data/WeeklyStatsObject.java
@@ -1,7 +1,7 @@
 package com.conveyal.traffic.app.data;
 
-import com.conveyal.traffic.data.stats.SummaryStatistics;
-import com.conveyal.traffic.data.stats.SummaryStatisticsComparison;
+import io.opentraffic.engine.data.stats.SummaryStatistics;
+import io.opentraffic.engine.data.stats.SummaryStatisticsComparison;
 
 public class WeeklyStatsObject {
 

--- a/src/main/java/com/conveyal/traffic/app/engine/Engine.java
+++ b/src/main/java/com/conveyal/traffic/app/engine/Engine.java
@@ -1,15 +1,15 @@
 package com.conveyal.traffic.app.engine;
 
+import com.conveyal.traffic.app.TrafficEngineApp;
+import com.vividsolutions.jts.geom.Point;
+import io.opentraffic.engine.TrafficEngine;
+import io.opentraffic.engine.geom.GPSPoint;
+import io.opentraffic.engine.osm.OSMArea;
+
 import java.io.File;
-import java.util.*;
+import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.conveyal.traffic.TrafficEngine;
-import com.conveyal.traffic.app.TrafficEngineApp;
-import com.conveyal.traffic.geom.GPSPoint;
-import com.conveyal.traffic.osm.OSMArea;
-import com.vividsolutions.jts.geom.Point;
 
 
 public class Engine {

--- a/src/main/java/com/conveyal/traffic/app/engine/Engine.java
+++ b/src/main/java/com/conveyal/traffic/app/engine/Engine.java
@@ -38,7 +38,7 @@ public class Engine {
 
 		Integer numberOfWorkerCores;
 		try {
-			numberOfWorkerCores = Integer.parseInt(TrafficEngineApp.appProps.getProperty("writeStatistics"));
+			numberOfWorkerCores = Integer.parseInt(TrafficEngineApp.appProps.getProperty("application.numberOfWorkerCores"));
 		} catch(Exception e) {
 			numberOfWorkerCores = Runtime.getRuntime().availableProcessors() / 2;
 			log.log(Level.INFO, "Property numberOfWorkerCores not set, defaulting to " + numberOfWorkerCores + " cores.");

--- a/src/main/java/com/conveyal/traffic/app/routing/Routing.java
+++ b/src/main/java/com/conveyal/traffic/app/routing/Routing.java
@@ -2,9 +2,9 @@ package com.conveyal.traffic.app.routing;
 
 
 import com.beust.jcommander.internal.Maps;
-import com.conveyal.traffic.data.SpatialDataItem;
-import com.conveyal.traffic.geom.StreetSegment;
-import com.conveyal.traffic.data.stats.SummaryStatistics;
+import io.opentraffic.engine.data.SpatialDataItem;
+import io.opentraffic.engine.geom.StreetSegment;
+import io.opentraffic.engine.data.stats.SummaryStatistics;
 import com.conveyal.traffic.app.TrafficEngineApp;
 import com.google.common.collect.Lists;
 import com.vividsolutions.jts.geom.Envelope;

--- a/src/main/java/com/conveyal/traffic/app/tiles/TrafficTileRequest.java
+++ b/src/main/java/com/conveyal/traffic/app/tiles/TrafficTileRequest.java
@@ -1,9 +1,9 @@
 package com.conveyal.traffic.app.tiles;
 
-import com.conveyal.traffic.data.SpatialDataItem;
-import com.conveyal.traffic.data.stats.SummaryStatisticsComparison;
-import com.conveyal.traffic.geom.StreetSegment;
-import com.conveyal.traffic.data.stats.SummaryStatistics;
+import io.opentraffic.engine.data.SpatialDataItem;
+import io.opentraffic.engine.data.stats.SummaryStatisticsComparison;
+import io.opentraffic.engine.geom.StreetSegment;
+import io.opentraffic.engine.data.stats.SummaryStatistics;
 import com.conveyal.traffic.app.TrafficEngineApp;
 import com.google.common.base.Charsets;
 import com.google.common.hash.HashCode;


### PR DESCRIPTION
The traffic-engine groupId + imports needed updating for the code to compile. The `numberOfWorkerCores` parameter was also parsed incorrectly, which is also fixed.
#3 should be caused by the same problems.
