### PR TITLE
Update application.vex URI to working endpoint

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -15,7 +15,7 @@ application.data.trafficTileDirectory=/Users/dbenoff/Downloads/data/data/tiles/
 application.enableTimeZoneConversion=false
 
 #application.vex=http://localhost:9002
-application.vex=http://osm.conveyal.com/vex
+application.vex=http://osm.conveyal.com
 
 application.osmCacheSize=100000
 


### PR DESCRIPTION
Complements https://github.com/opentraffic/traffic-engine-app/issues/2 - using the old example application.conf file produces an error when the server fetches data from `http://osm.conveyal.com`. This updates the `vex` configuration to use the working URI.